### PR TITLE
Fixes typo so the lights can be turned on and off remotely

### DIFF
--- a/nanoleaf/aurora.py
+++ b/nanoleaf/aurora.py
@@ -117,7 +117,7 @@ class Aurora(object):
     @on.setter
     def on(self, value: bool):
         """Turns the device on/off. True = on, False = off"""
-        data = {"on": value}
+        data = {"on": {"value": value}}
         self.__put("state", data)
 
     @property


### PR DESCRIPTION
This is to allow `light.on = True` to work without returning an error because the json you were pushing was in the incorrect format.